### PR TITLE
Feature: add support for strict/loose conditions

### DIFF
--- a/src/Concerns/HasConditions.php
+++ b/src/Concerns/HasConditions.php
@@ -50,6 +50,16 @@ trait HasConditions
     }
 
     /**
+     * Returns whether the condition set has any conditions.
+     *
+     * @unreleased
+     */
+    public function hasConditions(): bool
+    {
+        return ! empty($this->conditions);
+    }
+
+    /**
      * @since 1.0.0
      *
      * @param string|C|Closure $condition

--- a/src/Contracts/ConditionSet.php
+++ b/src/Contracts/ConditionSet.php
@@ -34,6 +34,13 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
     public function getConditions(): array;
 
     /**
+     * Returns true if the set has conditions.
+     *
+     * @unreleased
+     */
+    public function hasConditions(): bool;
+
+    /**
      * Add one or more conditions to the set;
      *
      * @since 1.0.0

--- a/src/FieldCondition.php
+++ b/src/FieldCondition.php
@@ -27,6 +27,8 @@ class FieldCondition implements Condition
     /** @var string */
     protected $comparisonOperator;
 
+    protected $strict = false;
+
     /**
      * Create a new FieldCondition.
      *
@@ -72,17 +74,21 @@ class FieldCondition implements Condition
      */
     public function passes(array $values): bool
     {
-        if ( ! isset($values[$this->field])) {
+        if (!isset($values[$this->field])) {
             throw new InvalidArgumentException("Field {$this->field} not found in test values.");
         }
 
         $testValue = $values[$this->field];
 
+        if ($this->strict && $this->comparisonOperator !== '!=' && gettype($testValue) !== gettype($this->value)) {
+            return false;
+        }
+
         switch ($this->comparisonOperator) {
             case '=':
-                return $testValue === $this->value;
+                return $testValue == $this->value;
             case '!=':
-                return $testValue !== $this->value;
+                return $this->strict ? $testValue !== $this->value : $testValue != $this->value;
             case '>':
                 return $testValue > $this->value;
             case '>=':
@@ -92,9 +98,9 @@ class FieldCondition implements Condition
             case '<=':
                 return $testValue <= $this->value;
             case 'contains':
-                return ('' === $this->value || false !== strpos($testValue, $this->value));
+                return ('' == $this->value || false !== strpos($testValue, $this->value));
             case 'not_contains':
-                return ('' === $this->value || false === strpos($testValue, $this->value));
+                return ('' == $this->value || false === strpos($testValue, $this->value));
         }
     }
 
@@ -103,7 +109,19 @@ class FieldCondition implements Condition
      */
     public function fails(array $values): bool
     {
-        return ! $this->passes($values);
+        return !$this->passes($values);
+    }
+
+    /**
+     * Sets the condition to strict mode.
+     *
+     * @unreleased
+     */
+    public function strict(bool $strict = true): self
+    {
+        $this->strict = $strict;
+
+        return $this;
     }
 
     /**
@@ -113,7 +131,7 @@ class FieldCondition implements Condition
      */
     protected function isInvalidComparisonOperator(string $operator): bool
     {
-        return ! in_array($operator, static::COMPARISON_OPERATORS, true);
+        return !in_array($operator, static::COMPARISON_OPERATORS, true);
     }
 
     /**
@@ -123,6 +141,6 @@ class FieldCondition implements Condition
      */
     protected function isInvalidLogicalOperator(string $operator): bool
     {
-        return ! in_array($operator, Condition::LOGICAL_OPERATORS, true);
+        return !in_array($operator, Condition::LOGICAL_OPERATORS, true);
     }
 }

--- a/src/FieldCondition.php
+++ b/src/FieldCondition.php
@@ -64,6 +64,7 @@ class FieldCondition implements Condition
             'type' => static::TYPE,
             'field' => $this->field,
             'value' => $this->value,
+            'strictComparison' => $this->strict,
             'comparisonOperator' => $this->comparisonOperator,
             'logicalOperator' => $this->logicalOperator,
         ];

--- a/tests/unit/Concerns/HasConditionsTest.php
+++ b/tests/unit/Concerns/HasConditionsTest.php
@@ -24,6 +24,18 @@ class HasConditionsTest extends TestCase
         self::assertCount(2, $conditionSet->getConditions());
     }
 
+    /**
+     * @unreleased
+     */
+    public function testShouldCheckWhetherSetHasConditionsOrNot()
+    {
+        $conditionSet = new ConditionSet();
+        self::assertFalse($conditionSet->hasConditions());
+
+        $conditionSet->append($this->createMock(Condition::class));
+        self::assertTrue($conditionSet->hasConditions());
+    }
+
     public function testShouldAddAndConditionUsingWhereMethod()
     {
         $conditionSet = new ConditionSet();

--- a/tests/unit/FieldConditionTest.php
+++ b/tests/unit/FieldConditionTest.php
@@ -20,21 +20,51 @@ class FieldConditionTest extends TestCase
     }
 
     /**
+     * @unreleased add loosely equal conditions
      * @since 1.0.0
      */
     public function passConditionsDataProviders(): array
     {
         return [
             ['foo', '=', 'foo'],
+            [10, '=', '10.00'],
             ['foo', '!=', 'bar'],
             [5, '>', 1],
+            [10, '>', '1'],
             [5, '>=', 5],
             [1, '<', 5],
             [5, '<=', 5],
             ['foo', 'contains', 'oo'],
+            ['1234', 'contains', '3'],
             ['foo', 'not_contains', 'bar'],
         ];
     }
+
+    /**
+     * @unreleased
+     *
+     * @dataProvider passStrictConditionsDataProviders
+     */
+    public function testPassingStrictConditions($valueToCompare, $comparisonOperator, $conditionalValue)
+    {
+        $condition = new FieldCondition('field', $comparisonOperator, $conditionalValue);
+        $condition->strict();
+
+        $this->assertTrue($condition->passes(['field' => $valueToCompare]));
+    }
+
+    public function passStrictConditionsDataProviders(): array
+    {
+        return [
+            [10, '=', 10],
+            [10, '!=', '10'],
+            [10, '>', 5],
+            [10, '>=', 10],
+            [10, '<', 15],
+            [10, '<=', 10],
+        ];
+    }
+
 
     /**
      * @since 1.0.0
@@ -62,6 +92,36 @@ class FieldConditionTest extends TestCase
             [5, '<=', 0],
             ['foo', 'contains', 'bar'],
             ['foo', 'not_contains', 'foo'],
+        ];
+    }
+
+    /**
+     * @unreleased
+     *
+     * @dataProvider failStrictConditionsDataProviders
+     */
+    public function testFailingStrictConditions($valueToCompare, $comparisonOperator, $conditionalValue)
+    {
+        $condition = new FieldCondition('field', $comparisonOperator, $conditionalValue);
+        $condition->strict();
+
+        $this->assertTrue($condition->fails(['field' => $valueToCompare]));
+    }
+
+    /**
+     * @unreleased
+     */
+    public function failStrictConditionsDataProviders(): array
+    {
+        return [
+            [10, '=', '10'],
+            [10, '!=', 10],
+            [10, '>', 15],
+            [10, '>=', 15],
+            [10, '<', 5],
+            [10, '<=', 5],
+            ['2', 'contains', 2],
+            ['2', 'not_contains', '2'],
         ];
     }
 

--- a/tests/unit/FieldConditionTest.php
+++ b/tests/unit/FieldConditionTest.php
@@ -136,6 +136,7 @@ class FieldConditionTest extends TestCase
             'type' => 'basic',
             'field' => 'field',
             'comparisonOperator' => '=',
+            'strictComparison' => false,
             'value' => 'foo',
             'logicalOperator' => 'and',
         ], $condition->jsonSerialize());


### PR DESCRIPTION
While integrating this I came to find that making sure field types are always set is tricky. It especially gets funky when comparing things like integers and floats. After some reflection, I realized that when it comes to fields and basic comparisons, most of the time an equivalent (loose) comparison is more intuitive.

Fact of the matter is, the system as it is isn't even consistent. Our equivalence operators (== and !=) were strict, but ranger operators (>, >=, <, <=) are loose in PHP. So depending on what operator was used it was strict or loose. Hmm.

This PR makes conditions loose by default and adds a `FieldCondition::strict()` method to allow for a "strict mode" to be activated for a given field. It then adds additional checking in strict mode to make all operators type-strict.

My only internal debate for this is whether "strict mode" should be a property of the condition or the condition set. It feels like a `$set->passesStrictly()` would be kind of neat. But that would mean its not possible for a set to be mixed, and it feels like the condition itself should determine that (because, well, that _is_ how conditions work).

Also, I did think about adding more operators, but I decided that's more confusing as an API, especially when it comes to range operators. I think 95% of the time folks will want loose operators, and this keeps things simple.

Open to suggestions, but I do think adding a strict mode in some regard is valuable, bringing consistency to the framework, and I think it should be loose by default.