### PR TITLE
fix: correct condition set return type implementation for PHP 7.0 compatibility

### DIFF
--- a/src/Concerns/HasConditions.php
+++ b/src/Concerns/HasConditions.php
@@ -65,8 +65,6 @@ trait HasConditions
      * @param string|C|Closure $condition
      * @param string|null $comparisonOperator
      * @param mixed|null $value
-     *
-     * @return static
      */
     public function where($condition, string $comparisonOperator = null, $value = null): ConditionSet
     {

--- a/src/Concerns/HasConditions.php
+++ b/src/Concerns/HasConditions.php
@@ -65,8 +65,10 @@ trait HasConditions
      * @param string|C|Closure $condition
      * @param string|null $comparisonOperator
      * @param mixed|null $value
+     *
+     * @return static
      */
-    public function where($condition, string $comparisonOperator = null, $value = null): self
+    public function where($condition, string $comparisonOperator = null, $value = null): ConditionSet
     {
         return $this->and($condition, $comparisonOperator, $value);
     }
@@ -78,7 +80,7 @@ trait HasConditions
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function and($condition, string $comparisonOperator = null, $value = null): self
+    public function and($condition, string $comparisonOperator = null, $value = null): ConditionSet
     {
         $this->conditions[] = $this->createCondition($condition, $comparisonOperator, $value, 'and');
 
@@ -92,7 +94,7 @@ trait HasConditions
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function or($condition, string $comparisonOperator = null, $value = null): self
+    public function or($condition, string $comparisonOperator = null, $value = null): ConditionSet
     {
         $this->conditions[] = $this->createCondition($condition, $comparisonOperator, $value, 'or');
 

--- a/src/Concerns/HasConditions.php
+++ b/src/Concerns/HasConditions.php
@@ -60,6 +60,7 @@ trait HasConditions
     }
 
     /**
+     * @unreleased return ConditionSet type for PHP 7.0 compatibility
      * @since 1.0.0
      *
      * @param string|C|Closure $condition
@@ -72,6 +73,7 @@ trait HasConditions
     }
 
     /**
+     * @unreleased return ConditionSet type for PHP 7.0 compatibility
      * @since 1.0.0
      *
      * @param string|C|Closure $condition
@@ -86,6 +88,7 @@ trait HasConditions
     }
 
     /**
+     * @unreleased return ConditionSet type for PHP 7.0 compatibility
      * @since 1.0.0
      *
      * @param string|C|Closure $condition

--- a/src/Contracts/ConditionSet.php
+++ b/src/Contracts/ConditionSet.php
@@ -58,7 +58,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function where($condition, string $comparisonOperator = null, $value = null): self;
+    public function where($condition, string $comparisonOperator = null, $value = null): ConditionSet;
 
     /**
      * @since 1.0.0
@@ -67,7 +67,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function and($condition, string $comparisonOperator = null, $value = null): self;
+    public function and($condition, string $comparisonOperator = null, $value = null): ConditionSet;
 
     /**
      * @since 1.0.0
@@ -76,7 +76,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function or($condition, string $comparisonOperator = null, $value = null): self;
+    public function or($condition, string $comparisonOperator = null, $value = null): ConditionSet;
 
     /**
      * Returns true if all conditions in the set pass.

--- a/src/Contracts/ConditionSet.php
+++ b/src/Contracts/ConditionSet.php
@@ -14,17 +14,6 @@ use JsonSerializable;
 interface ConditionSet extends IteratorAggregate, JsonSerializable
 {
     /**
-     * Constructs the set with the given conditions
-     *
-     * @since 1.0.0
-     *
-     * @param C ...$conditions
-     *
-     * @return void
-     */
-    public function __construct(...$conditions);
-
-    /**
      * Returns all conditions in the set.
      *
      * @since 1.0.0

--- a/src/Contracts/ConditionSet.php
+++ b/src/Contracts/ConditionSet.php
@@ -47,7 +47,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function where($condition, string $comparisonOperator = null, $value = null): ConditionSet;
+    public function where($condition, string $comparisonOperator = null, $value = null): self;
 
     /**
      * @since 1.0.0
@@ -56,7 +56,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function and($condition, string $comparisonOperator = null, $value = null): ConditionSet;
+    public function and($condition, string $comparisonOperator = null, $value = null): self;
 
     /**
      * @since 1.0.0
@@ -65,7 +65,7 @@ interface ConditionSet extends IteratorAggregate, JsonSerializable
      * @param string|null $comparisonOperator
      * @param mixed|null $value
      */
-    public function or($condition, string $comparisonOperator = null, $value = null): ConditionSet;
+    public function or($condition, string $comparisonOperator = null, $value = null): self;
 
     /**
      * Returns true if all conditions in the set pass.

--- a/src/NestedCondition.php
+++ b/src/NestedCondition.php
@@ -11,6 +11,7 @@ use StellarWP\FieldConditions\Contracts\ConditionSet;
 /**
  * A condition that holds and evaluates multiple conditions.
  *
+ * @unreleased implement the ConditionSet interface
  * @since 1.0.0
  *
  * @uses HasConditions<Condition>

--- a/src/NestedCondition.php
+++ b/src/NestedCondition.php
@@ -2,9 +2,11 @@
 
 namespace StellarWP\FieldConditions;
 
+use ArrayIterator;
 use StellarWP\FieldConditions\Concerns\HasConditions;
 use StellarWP\FieldConditions\Concerns\HasLogicalOperator;
 use StellarWP\FieldConditions\Contracts\Condition;
+use StellarWP\FieldConditions\Contracts\ConditionSet;
 
 /**
  * A condition that holds and evaluates multiple conditions.
@@ -13,7 +15,7 @@ use StellarWP\FieldConditions\Contracts\Condition;
  *
  * @uses HasConditions<Condition>
  */
-class NestedCondition implements Condition
+class NestedCondition implements Condition, ConditionSet
 {
     use HasLogicalOperator;
     use HasConditions;
@@ -47,5 +49,13 @@ class NestedCondition implements Condition
             'conditions' => $this->conditions,
             'boolean' => $this->logicalOperator,
         ];
+    }
+
+    /**
+     * @unreleased
+     */
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->conditions);
     }
 }

--- a/tests/unit/Concerns/HasConditionsTest.php
+++ b/tests/unit/Concerns/HasConditionsTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace unit\Concerns;
 
+use ArrayIterator;
 use InvalidArgumentException;
 use StellarWP\FieldConditions\Concerns\HasConditions;
 use StellarWP\FieldConditions\Concerns\HasLogicalOperator;
 use StellarWP\FieldConditions\Contracts\Condition;
+use StellarWP\FieldConditions\Contracts\ConditionSet as ConditionSetContract;
 use StellarWP\FieldConditions\FieldCondition;
 use StellarWP\FieldConditions\NestedCondition;
 use StellarWP\FieldConditions\Tests\TestCase;
+use Traversable;
+
 class HasConditionsTest extends TestCase
 {
     public function testShouldAppendAndGetConditions()
@@ -185,16 +189,26 @@ class HasConditionsTest extends TestCase
     }
 }
 
-class ConditionSet {
+class ConditionSet implements ConditionSetContract {
     use HasConditions;
 
     public function __construct(...$conditions)
     {
         $this->conditions = $conditions;
     }
+
+    public function jsonSerialize(): array
+    {
+        return [];
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->conditions);
+    }
 }
 
-class ConditionSetWithDifferentBaseClass {
+class ConditionSetWithDifferentBaseClass implements ConditionSetContract {
     use HasConditions;
 
     public function __construct(...$conditions)
@@ -205,6 +219,16 @@ class ConditionSetWithDifferentBaseClass {
     protected static function getBaseConditionClass(): string
     {
         return MockCondition::class;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [];
+    }
+
+    public function getIterator(): ArrayIterator
+    {
+        return new ArrayIterator($this->conditions);
     }
 }
 


### PR DESCRIPTION
The `ConditionSet` interface has the `where`, `or`, and `and` methods which are fluent — returning the interface. The `SimpleConditionSet` and `NestedCondition` sets were using contravariance in the return type, which isn't supported until 7.2. At this point we're aiming to be 7.0 compatible, so we'll need to return the interface in those methods. This is slightly limiting, but not too bad.